### PR TITLE
Change base url to include www

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://gonum.org/"  # End your URL with a `/` trailing slash.
+baseurl = "https://www.gonum.org/"  # End your URL with a `/` trailing slash.
 title = "Gonum"
 copyright = "&copy; 2017 Gonum Authors"
 theme = "academic"


### PR DESCRIPTION
Netlify strongly recommends having the base url include the www. https://www.netlify.com/blog/2016/01/12/this-weekends-ddos-attack-and-whats-in-a-cname/. This commit helps follow by those rules